### PR TITLE
fix(types): update loader parallel type

### DIFF
--- a/test/Use.js
+++ b/test/Use.js
@@ -53,3 +53,14 @@ test('toConfig', () => {
   expect(config.__ruleTypes).toStrictEqual(['rule']);
   expect(config.__useName).toBe('beta');
 });
+
+test('toConfig with parallel options', () => {
+  const use = new Use();
+
+  use.loader('babel-loader').parallel({ maxWorkers: 2 });
+
+  expect(use.toConfig()).toStrictEqual({
+    loader: 'babel-loader',
+    parallel: { maxWorkers: 2 },
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,8 @@
-import { Configuration, RuleSetRule } from '@rspack/core';
+import type {
+  Configuration,
+  RuleSetLoaderWithOptions,
+  RuleSetRule,
+} from '@rspack/core';
 
 // The compiler type of Rspack / webpack are mismatch,
 // so we use a loose type here to allow using webpack plugins.
@@ -386,10 +390,14 @@ export declare namespace RspackChain {
     [name: string]: any;
   }
 
+  type LoaderParallelOptions = NonNullable<
+    RuleSetLoaderWithOptions['parallel']
+  >;
+
   class Use<Parent = Rule> extends ChainedMap<Parent> implements Orderable {
     loader(value: string): this;
     options(value: LoaderOptions): this;
-    parallel(value: boolean): this;
+    parallel(value: LoaderParallelOptions): this;
 
     tap(f: (options: LoaderOptions) => LoaderOptions): this;
 

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -99,6 +99,7 @@ config
   .loader('babel-loader')
   .options({})
   .parallel(true)
+  .parallel({ maxWorkers: 2 })
   .end()
   .use('eslint')
   .loader('eslint-loader')


### PR DESCRIPTION
## Summary

This PR updates the chained loader API types to match Rspack's `RuleSetLoaderWithOptions['parallel']`, allowing `.parallel({ maxWorkers })` in addition to boolean values. It also adds runtime and type coverage for object-based parallel options.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Use.js`
- `prettier --check types/index.d.ts test/Use.js types/test/rspack-chain-tests.ts`