### PR TITLE
feat: add extends chain API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ class RspackChain extends ChainedMap {
       'bail',
       'cache',
       'dependencies',
+      'extends',
       'ignoreWarnings',
       'loader',
       'name',

--- a/test/RspackChain.js
+++ b/test/RspackChain.js
@@ -1,0 +1,10 @@
+import { RspackChain } from '../src/index';
+
+test('extends', () => {
+  const config = new RspackChain();
+
+  expect(config.extends('./rspack.base.js')).toBe(config);
+  expect(config.toConfig()).toStrictEqual({
+    extends: './rspack.base.js',
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,6 +86,7 @@ export declare class RspackChain extends __Config.ChainedMap<void> {
   bail(value: RspackConfig['bail']): this;
   cache(value: RspackConfig['cache']): this;
   dependencies(value: RspackConfig['dependencies']): this;
+  extends(value: RspackConfig['extends']): this;
   ignoreWarnings(value: RspackConfig['ignoreWarnings']): this;
   loader(value: RspackConfig['loader']): this;
   name(value: RspackConfig['name']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -364,6 +364,7 @@ config
   .cache({
     type: 'persistent',
   })
+  .extends('./rspack.base.js')
   .devtool('hidden-source-map')
   .devtool(false)
   .context('')


### PR DESCRIPTION
## Summary

This PR adds the top-level `.extends()` chain API so rspack-chain can represent Rspack's `extends` configuration option. It wires the runtime shorthand, public type declaration, and type/runtime coverage for the new API.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/RspackChain.js`
- `prettier --check src/index.js types/index.d.ts types/test/rspack-chain-tests.ts test/RspackChain.js`