### PR TITLE
feat: add incremental chain API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ class RspackChain extends ChainedMap {
       'infrastructureLogging',
       'snapshot',
       'lazyCompilation',
+      'incremental',
     ]);
   }
 

--- a/test/RspackChain.js
+++ b/test/RspackChain.js
@@ -8,3 +8,12 @@ test('extends', () => {
     extends: './rspack.base.js',
   });
 });
+
+test('incremental', () => {
+  const config = new RspackChain();
+
+  expect(config.incremental('safe')).toBe(config);
+  expect(config.toConfig()).toStrictEqual({
+    incremental: 'safe',
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,6 +93,7 @@ export declare class RspackChain extends __Config.ChainedMap<void> {
   infrastructureLogging(value: RspackConfig['infrastructureLogging']): this;
   snapshot(value: RspackConfig['snapshot']): this;
   lazyCompilation(value: RspackConfig['lazyCompilation']): this;
+  incremental(value: RspackConfig['incremental']): this;
 
   entry(name: string): RspackChain.EntryPoint;
   plugin(name: string): RspackChain.Plugin<this, PluginInstance>;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -390,6 +390,9 @@ config
     publicPath: true,
     modules: false,
   })
+  .incremental({
+    silent: true,
+  })
   .target('web')
   .watch(true)
   .watchOptions({})


### PR DESCRIPTION
## Summary

This PR adds the top-level `.incremental()` chain API so rspack-chain can represent Rspack's incremental build option. It updates the runtime shorthand, public type declaration, and type/runtime coverage for the new API.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/RspackChain.js`
- `prettier --check src/index.js types/index.d.ts types/test/rspack-chain-tests.ts test/RspackChain.js`