### PR TITLE
feat: add output asyncChunks API

### DIFF
--- a/src/Output.js
+++ b/src/Output.js
@@ -5,6 +5,7 @@ export default class extends ChainedMap {
     super(parent);
     this.extend([
       'assetModuleFilename',
+      'asyncChunks',
       'bundlerInfo',
       'chunkFilename',
       'chunkLoadTimeout',

--- a/test/Output.js
+++ b/test/Output.js
@@ -18,3 +18,12 @@ test('shorthand methods', () => {
 
   expect(output.entries()).toStrictEqual(obj);
 });
+
+test('asyncChunks', () => {
+  const output = new Output();
+
+  expect(output.asyncChunks(false)).toBe(output);
+  expect(output.entries()).toStrictEqual({
+    asyncChunks: false,
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,6 +181,7 @@ export declare namespace RspackChain {
 
   class Output extends ChainedMap<RspackChain> {
     assetModuleFilename(value: RspackOutput['assetModuleFilename']): this;
+    asyncChunks(value: RspackOutput['asyncChunks']): this;
     bundlerInfo(value: RspackOutput['bundlerInfo']): this;
     chunkFilename(value: RspackOutput['chunkFilename']): this;
     chunkLoadTimeout(value: RspackOutput['chunkLoadTimeout']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -34,7 +34,8 @@ config
   .entryPoints.delete('main')
   .end()
   // output
-  .output.bundlerInfo({
+  .output.asyncChunks(true)
+  .bundlerInfo({
     force: false,
   })
   .chunkFilename('')


### PR DESCRIPTION
## Summary

This PR adds `output.asyncChunks()` so rspack-chain can configure Rspack's `output.asyncChunks` option through the chained output API. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Output.js`
- `prettier --check src/Output.js types/index.d.ts test/Output.js types/test/rspack-chain-tests.ts`