### PR TITLE
feat: add resolve fullySpecified API

### DIFF
--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -29,6 +29,7 @@ export default class extends ChainedMap {
 
     this.extend([
       'enforceExtension',
+      'fullySpecified',
       'symlinks',
       'preferRelative',
       'preferAbsolute',

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -30,7 +30,6 @@ const Rule = Orderable(
       this.rules = new ChainedMap(this);
       this.oneOfs = new ChainedMap(this);
       this.resolve = new Resolve(this);
-      this.resolve.extend(['fullySpecified']);
       this.extend([
         'dependency',
         'enforce',

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -35,8 +35,8 @@ test('toConfig empty', () => {
 test('toConfig with values', () => {
   const resolve = new Resolve();
 
-  resolve
-    .modules.add('src')
+  resolve.modules
+    .add('src')
     .end()
     .extensions.add('.js')
     .end()
@@ -147,6 +147,15 @@ test('tsConfig string', () => {
   resolve.tsConfig('./tsconfig.json').end();
   expect(resolve.toConfig()).toStrictEqual({
     tsConfig: './tsconfig.json',
+  });
+});
+
+test('fullySpecified', () => {
+  const resolve = new Resolve();
+
+  expect(resolve.fullySpecified(true)).toBe(resolve);
+  expect(resolve.toConfig()).toStrictEqual({
+    fullySpecified: true,
   });
 });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -294,16 +294,14 @@ export declare namespace RspackChain {
     >;
     byDependency: TypedChainedMap<this, RspackResolve['byDependency']>;
     enforceExtension(value: RspackResolve['enforceExtension']): this;
+    fullySpecified(value: RspackResolve['fullySpecified']): this;
     symlinks(value: RspackResolve['symlinks']): this;
     preferRelative(value: RspackResolve['preferRelative']): this;
     preferAbsolute(value: RspackResolve['preferAbsolute']): this;
 
     tsConfig(value: RspackResolve['tsConfig']): this;
   }
-
-  class RuleResolve<T = RspackChain> extends Resolve<T> {
-    fullySpecified(value: boolean): this;
-  }
+  class RuleResolve<T = RspackChain> extends Resolve<T> {}
 
   class ResolveLoader extends Resolve {
     modules: ChainedSet<this>;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -158,6 +158,7 @@ config
     configFile: './tsconfig.json',
     references: 'auto',
   })
+  .fullySpecified(false)
   .modules.add('index.js')
   .end()
   .aliasFields.add('foo')


### PR DESCRIPTION
## Summary

This PR adds `resolve.fullySpecified()` to the base resolve chain so top-level resolve configuration can set Rspack's `fullySpecified` option. It also keeps rule-level resolve behavior aligned by using the shared Resolve shorthand list, and adds type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Resolve.js test/Rule.js`
- `prettier --check src/Resolve.js src/Rule.js types/index.d.ts test/Resolve.js types/test/rspack-chain-tests.ts`