### PR TITLE
feat: add rule descriptionData API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -33,6 +33,7 @@ const Rule = Orderable(
       this.resolve.extend(['fullySpecified']);
       this.extend([
         'dependency',
+        'descriptionData',
         'enforce',
         'issuer',
         'issuerLayer',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -130,6 +130,9 @@ test('toConfig with values', () => {
     .post()
     .pre()
     .test(/\.js$/)
+    .descriptionData({
+      type: 'module',
+    })
     .use('babel')
     .loader('babel-loader')
     .options({ presets: ['alpha'] })
@@ -147,6 +150,9 @@ test('toConfig with values', () => {
 
   expect(rule.toConfig()).toStrictEqual({
     test: /\.js$/,
+    descriptionData: {
+      type: 'module',
+    },
     enforce: 'pre',
     include: ['alpha', 'beta'],
     exclude: ['alpha', 'beta'],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -322,6 +322,7 @@ export declare namespace RspackChain {
     resolve: RuleResolve<Rule<T>>;
 
     dependency(value: RspackRuleSet['dependency']): this;
+    descriptionData(value: RspackRuleSet['descriptionData']): this;
     enforce(value: RspackRuleSet['enforce']): this;
     issuer(value: RspackRuleSet['issuer']): this;
     issuerLayer(value: RspackRuleSet['issuerLayer']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -82,6 +82,9 @@ config
   })
   .enforce('pre')
   .dependency('asd')
+  .descriptionData({
+    type: 'module',
+  })
   .issuer('asd')
   .issuerLayer('asd')
   .sideEffects(true)


### PR DESCRIPTION
## Summary

This PR adds `rule.descriptionData()` so rspack-chain can configure Rspack's rule-level `descriptionData` condition. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Rule.js`
- `prettier --check src/Rule.js types/index.d.ts test/Rule.js types/test/rspack-chain-tests.ts`