### PR TITLE
feat: add output cssFilename API

### DIFF
--- a/src/Output.js
+++ b/src/Output.js
@@ -14,6 +14,7 @@ export default class extends ChainedMap {
       'chunkFormat',
       'enabledChunkLoadingTypes',
       'crossOriginLoading',
+      'cssFilename',
       'devtoolFallbackModuleFilenameTemplate',
       'devtoolModuleFilenameTemplate',
       'devtoolNamespace',

--- a/test/Output.js
+++ b/test/Output.js
@@ -27,3 +27,12 @@ test('asyncChunks', () => {
     asyncChunks: false,
   });
 });
+
+test('cssFilename', () => {
+  const output = new Output();
+
+  expect(output.cssFilename('css/[name].css')).toBe(output);
+  expect(output.entries()).toStrictEqual({
+    cssFilename: 'css/[name].css',
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -190,6 +190,7 @@ export declare namespace RspackChain {
     chunkLoading(value: RspackOutput['chunkLoading']): this;
     chunkFormat(value: RspackOutput['chunkFormat']): this;
     crossOriginLoading(value: RspackOutput['crossOriginLoading']): this;
+    cssFilename(value: RspackOutput['cssFilename']): this;
     devtoolFallbackModuleFilenameTemplate(
       value: RspackOutput['devtoolFallbackModuleFilenameTemplate'],
     ): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -42,6 +42,7 @@ config
   .chunkLoadTimeout(1000)
   .chunkLoadingGlobal('xasd')
   .crossOriginLoading('anonymous')
+  .cssFilename('css/[name].css')
   .devtoolFallbackModuleFilenameTemplate('')
   .devtoolNamespace('')
   .devtoolModuleFilenameTemplate('')


### PR DESCRIPTION
## Summary

This PR adds `output.cssFilename()` so rspack-chain can configure Rspack's CSS output filename option through the chained output API. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Output.js`
- `prettier --check src/Output.js types/index.d.ts test/Output.js types/test/rspack-chain-tests.ts`