### PR TITLE
feat: add resolve pnp API

### DIFF
--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -30,6 +30,7 @@ export default class extends ChainedMap {
     this.extend([
       'enforceExtension',
       'fullySpecified',
+      'pnp',
       'symlinks',
       'preferRelative',
       'preferAbsolute',

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -159,6 +159,15 @@ test('fullySpecified', () => {
   });
 });
 
+test('pnp', () => {
+  const resolve = new Resolve();
+
+  expect(resolve.pnp(true)).toBe(resolve);
+  expect(resolve.toConfig()).toStrictEqual({
+    pnp: true,
+  });
+});
+
 test('tsConfig object', () => {
   const resolve = new Resolve();
   resolve.tsConfig({

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -297,6 +297,7 @@ export declare namespace RspackChain {
     byDependency: TypedChainedMap<this, RspackResolve['byDependency']>;
     enforceExtension(value: RspackResolve['enforceExtension']): this;
     fullySpecified(value: RspackResolve['fullySpecified']): this;
+    pnp(value: RspackResolve['pnp']): this;
     symlinks(value: RspackResolve['symlinks']): this;
     preferRelative(value: RspackResolve['preferRelative']): this;
     preferAbsolute(value: RspackResolve['preferAbsolute']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -163,6 +163,7 @@ config
     references: 'auto',
   })
   .fullySpecified(false)
+  .pnp(true)
   .modules.add('index.js')
   .end()
   .aliasFields.add('foo')


### PR DESCRIPTION
## Summary

This PR adds `resolve.pnp()` so rspack-chain can configure Rspack's Yarn PnP resolve option through the shared resolve chain. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Resolve.js`
- `prettier --check src/Resolve.js types/index.d.ts test/Resolve.js types/test/rspack-chain-tests.ts`