### PR TITLE
feat: add rule phase API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -38,6 +38,7 @@ const Rule = Orderable(
         'issuerLayer',
         'layer',
         'mimetype',
+        'phase',
         'parser',
         'generator',
         'resource',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -133,6 +133,7 @@ test('toConfig with values', () => {
     .descriptionData({
       type: 'module',
     })
+    .phase('source')
     .use('babel')
     .loader('babel-loader')
     .options({ presets: ['alpha'] })
@@ -153,6 +154,7 @@ test('toConfig with values', () => {
     descriptionData: {
       type: 'module',
     },
+    phase: 'source',
     enforce: 'pre',
     include: ['alpha', 'beta'],
     exclude: ['alpha', 'beta'],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,6 +328,7 @@ export declare namespace RspackChain {
     issuerLayer(value: RspackRuleSet['issuerLayer']): this;
     layer(value: RspackRuleSet['layer']): this;
     mimetype(value: RspackRuleSet['mimetype']): this;
+    phase(value: RspackRuleSet['phase']): this;
     parser(value: RspackRuleSet['parser']): this;
     generator(value: RspackRuleSet['generator']): this;
     resource(value: RspackRuleSet['resource']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -86,6 +86,7 @@ config
   .descriptionData({
     type: 'module',
   })
+  .phase('source')
   .issuer('asd')
   .issuerLayer('asd')
   .sideEffects(true)


### PR DESCRIPTION
## Summary

This PR adds `rule.phase()` so rspack-chain can configure Rspack's rule-level import phase condition. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Rule.js`
- `prettier --check src/Rule.js types/index.d.ts test/Rule.js types/test/rspack-chain-tests.ts`