### PR TITLE
feat: add use ident API

### DIFF
--- a/src/Use.js
+++ b/src/Use.js
@@ -7,7 +7,7 @@ export default Orderable(
     constructor(parent, name) {
       super(parent);
       this.name = name;
-      this.extend(['loader', 'options', 'parallel']);
+      this.extend(['ident', 'loader', 'options', 'parallel']);
     }
 
     tap(f) {

--- a/test/Use.js
+++ b/test/Use.js
@@ -64,3 +64,14 @@ test('toConfig with parallel options', () => {
     parallel: { maxWorkers: 2 },
   });
 });
+
+test('toConfig with ident', () => {
+  const use = new Use();
+
+  use.loader('babel-loader').ident('babel-loader-ident');
+
+  expect(use.toConfig()).toStrictEqual({
+    loader: 'babel-loader',
+    ident: 'babel-loader-ident',
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -397,6 +397,7 @@ export declare namespace RspackChain {
   >;
 
   class Use<Parent = Rule> extends ChainedMap<Parent> implements Orderable {
+    ident(value: NonNullable<RuleSetLoaderWithOptions['ident']>): this;
     loader(value: string): this;
     options(value: LoaderOptions): this;
     parallel(value: LoaderParallelOptions): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -100,6 +100,7 @@ config
   })
   .use('babel')
   .tap((config) => [])
+  .ident('babel-loader-ident')
   .loader('babel-loader')
   .options({})
   .parallel(true)


### PR DESCRIPTION
## Summary

This PR adds `use.ident()` so rspack-chain can configure Rspack loader use item identifiers. It updates the runtime shorthand, public type declaration, and type/runtime coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Use.js`
- `prettier --check src/Use.js types/index.d.ts test/Use.js types/test/rspack-chain-tests.ts`