### PR TITLE
fix(types): expose module defaultRule API

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -171,9 +171,11 @@ export declare namespace RspackChain {
   type RspackModule = Required<NonNullable<Configuration['module']>>;
 
   class Module extends ChainedMap<RspackChain> {
+    defaultRules: TypedChainedMap<this, { [key: string]: Rule }>;
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
     generator: ChainedMap<this>;
     parser: ChainedMap<this>;
+    defaultRule(name: string): Rule;
     rule(name: string): Rule;
     noParse(value: RspackModule['noParse']): this;
   }

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -67,6 +67,9 @@ config
   .end()
   // module
   .module.noParse(/.min.js$/)
+  .defaultRule('json')
+  .type('json')
+  .end()
   .generator.set('asset', {
     publicPath: 'assets/',
   })


### PR DESCRIPTION
## Summary

This PR exposes the existing `module.defaultRule()` API in the public TypeScript declarations. The runtime API and JavaScript tests already exist, so this adds the missing declaration surface and type coverage.

## Validation

- `tsc -p ./types/test/tsconfig.json`
- `rstest test/Module.js`
- `prettier --check types/index.d.ts types/test/rspack-chain-tests.ts test/Module.js`