### PR TITLE
feat: add output workerWasmLoading API

### DIFF
--- a/src/Output.js
+++ b/src/Output.js
@@ -38,6 +38,7 @@ export default class extends ChainedMap {
       'strictModuleErrorHandling',
       'strictModuleExceptionHandling',
       'workerChunkLoading',
+      'workerWasmLoading',
       'enabledLibraryTypes',
       'environment',
       'compareBeforeEmit',

--- a/test/Output.js
+++ b/test/Output.js
@@ -36,3 +36,12 @@ test('cssFilename', () => {
     cssFilename: 'css/[name].css',
   });
 });
+
+test('workerWasmLoading', () => {
+  const output = new Output();
+
+  expect(output.workerWasmLoading('fetch')).toBe(output);
+  expect(output.entries()).toStrictEqual({
+    workerWasmLoading: 'fetch',
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,6 +228,7 @@ export declare namespace RspackChain {
       value: RspackOutput['strictModuleExceptionHandling'],
     ): this;
     workerChunkLoading(value: RspackOutput['workerChunkLoading']): this;
+    workerWasmLoading(value: RspackOutput['workerWasmLoading']): this;
     enabledLibraryTypes(value: RspackOutput['enabledLibraryTypes']): this;
     environment(value: RspackOutput['environment']): this;
     compareBeforeEmit(value: RspackOutput['compareBeforeEmit']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -60,6 +60,7 @@ config
   .publicPath('/')
   .sourceMapFilename('index.js.map')
   .strictModuleExceptionHandling(true)
+  .workerWasmLoading('fetch')
   .iife(true)
   .webassemblyModuleFilename('[id].[hash].wasm')
   .clean({


### PR DESCRIPTION
## Summary

This PR exposes @rspack/core's `output.workerWasmLoading` option through rspack-chain and adds coverage for config generation and type usage.