### PR TITLE
feat: add rule scheme API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -44,6 +44,7 @@ const Rule = Orderable(
         'resource',
         'resourceFragment',
         'resourceQuery',
+        'scheme',
         'sideEffects',
         'with',
         'test',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -134,6 +134,7 @@ test('toConfig with values', () => {
       type: 'module',
     })
     .phase('source')
+    .scheme('data')
     .use('babel')
     .loader('babel-loader')
     .options({ presets: ['alpha'] })
@@ -155,6 +156,7 @@ test('toConfig with values', () => {
       type: 'module',
     },
     phase: 'source',
+    scheme: 'data',
     enforce: 'pre',
     include: ['alpha', 'beta'],
     exclude: ['alpha', 'beta'],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -339,6 +339,7 @@ export declare namespace RspackChain {
     resource(value: RspackRuleSet['resource']): this;
     resourceFragment(value: RspackRuleSet['resourceFragment']): this;
     resourceQuery(value: RspackRuleSet['resourceQuery']): this;
+    scheme(value: RspackRuleSet['scheme']): this;
     sideEffects(value: RspackRuleSet['sideEffects']): this;
     with(value: RspackRuleSet['with']): this;
     test(value: RspackRuleSet['test']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -91,6 +91,7 @@ config
     type: 'module',
   })
   .phase('source')
+  .scheme('data')
   .issuer('asd')
   .issuerLayer('asd')
   .sideEffects(true)


### PR DESCRIPTION
## Summary

This PR exposes @rspack/core's rule-level `scheme` option through rspack-chain and adds coverage for config generation and type usage.