### PR TITLE
feat: add rule extractSourceMap API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -34,6 +34,7 @@ const Rule = Orderable(
         'dependency',
         'descriptionData',
         'enforce',
+        'extractSourceMap',
         'issuer',
         'issuerLayer',
         'layer',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -133,6 +133,7 @@ test('toConfig with values', () => {
     .descriptionData({
       type: 'module',
     })
+    .extractSourceMap(true)
     .phase('source')
     .use('babel')
     .loader('babel-loader')
@@ -154,6 +155,7 @@ test('toConfig with values', () => {
     descriptionData: {
       type: 'module',
     },
+    extractSourceMap: true,
     phase: 'source',
     enforce: 'pre',
     include: ['alpha', 'beta'],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -329,6 +329,7 @@ export declare namespace RspackChain {
     dependency(value: RspackRuleSet['dependency']): this;
     descriptionData(value: RspackRuleSet['descriptionData']): this;
     enforce(value: RspackRuleSet['enforce']): this;
+    extractSourceMap(value: RspackRuleSet['extractSourceMap']): this;
     issuer(value: RspackRuleSet['issuer']): this;
     issuerLayer(value: RspackRuleSet['issuerLayer']): this;
     layer(value: RspackRuleSet['layer']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -90,6 +90,7 @@ config
   .descriptionData({
     type: 'module',
   })
+  .extractSourceMap(true)
   .phase('source')
   .issuer('asd')
   .issuerLayer('asd')


### PR DESCRIPTION
## Summary

This PR exposes @rspack/core's rule-level `extractSourceMap` option through rspack-chain and adds coverage for config generation and type usage.