### PR TITLE
feat: add rule loader API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -37,6 +37,7 @@ const Rule = Orderable(
         'issuer',
         'issuerLayer',
         'layer',
+        'loader',
         'mimetype',
         'phase',
         'parser',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -198,6 +198,17 @@ test('toConfig with test function', () => {
   expect(rule.toConfig()).toStrictEqual({ test });
 });
 
+test('toConfig with rule-level loader', () => {
+  const rule = new Rule();
+
+  rule.test(/\.js$/).loader('babel-loader');
+
+  expect(rule.toConfig()).toStrictEqual({
+    test: /\.js$/,
+    loader: 'babel-loader',
+  });
+});
+
 test('merge empty', () => {
   const rule = new Rule();
   const obj = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -332,6 +332,7 @@ export declare namespace RspackChain {
     issuer(value: RspackRuleSet['issuer']): this;
     issuerLayer(value: RspackRuleSet['issuerLayer']): this;
     layer(value: RspackRuleSet['layer']): this;
+    loader(value: NonNullable<RspackRuleSet['loader']>): this;
     mimetype(value: RspackRuleSet['mimetype']): this;
     phase(value: RspackRuleSet['phase']): this;
     parser(value: RspackRuleSet['parser']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -156,6 +156,10 @@ config
   .test(/\.mjs$/)
   .type('javascript/auto')
   .end()
+  .rule('loader-rule')
+  .test(/\.jsx$/)
+  .loader('babel-loader')
+  .end()
   .end()
   // resolve
   .resolve.alias.set('foo', 'bar')


### PR DESCRIPTION
## Summary

This PR exposes @rspack/core's rule-level `loader` option through rspack-chain and adds coverage for config generation and type usage.