### PR TITLE
feat: add rule options API

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -38,6 +38,7 @@ const Rule = Orderable(
         'issuerLayer',
         'layer',
         'mimetype',
+        'options',
         'phase',
         'parser',
         'generator',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -198,6 +198,17 @@ test('toConfig with test function', () => {
   expect(rule.toConfig()).toStrictEqual({ test });
 });
 
+test('toConfig with rule-level options', () => {
+  const rule = new Rule();
+
+  rule.test(/\.js$/).options({ presets: ['alpha'] });
+
+  expect(rule.toConfig()).toStrictEqual({
+    test: /\.js$/,
+    options: { presets: ['alpha'] },
+  });
+});
+
 test('merge empty', () => {
   const rule = new Rule();
   const obj = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -333,6 +333,7 @@ export declare namespace RspackChain {
     issuerLayer(value: RspackRuleSet['issuerLayer']): this;
     layer(value: RspackRuleSet['layer']): this;
     mimetype(value: RspackRuleSet['mimetype']): this;
+    options(value: RspackRuleSet['options']): this;
     phase(value: RspackRuleSet['phase']): this;
     parser(value: RspackRuleSet['parser']): this;
     generator(value: RspackRuleSet['generator']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -156,6 +156,10 @@ config
   .test(/\.mjs$/)
   .type('javascript/auto')
   .end()
+  .rule('options-rule')
+  .test(/\.jsx$/)
+  .options({})
+  .end()
   .end()
   // resolve
   .resolve.alias.set('foo', 'bar')


### PR DESCRIPTION
## Summary

This PR exposes @rspack/core's rule-level `options` option through rspack-chain and adds coverage for config generation and type usage.