### PR TITLE
fix: remove unsupported snapshot shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,6 @@ config
   .loader(loader)
   .name(name)
   .infrastructureLogging(infrastructureLogging)
-  .snapshot(snapshot)
   .lazyCompilation(lazyCompilation)
   .incremental(incremental);
 ```
@@ -1291,7 +1290,6 @@ config.merge({
   loader,
   mode,
   name,
-  snapshot,
   stats,
   target,
   watch,

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,6 @@ class RspackChain extends ChainedMap {
       'loader',
       'name',
       'infrastructureLogging',
-      'snapshot',
       'lazyCompilation',
       'incremental',
     ]);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -91,7 +91,6 @@ export declare class RspackChain extends __Config.ChainedMap<void> {
   loader(value: RspackConfig['loader']): this;
   name(value: RspackConfig['name']): this;
   infrastructureLogging(value: RspackConfig['infrastructureLogging']): this;
-  snapshot(value: RspackConfig['snapshot']): this;
   lazyCompilation(value: RspackConfig['lazyCompilation']): this;
   incremental(value: RspackConfig['incremental']): this;
 


### PR DESCRIPTION
## Summary

This PR removes the top-level `config.snapshot()` shorthand and its type/docs entries. Rspack removed the top-level `snapshot` option after it became a no-op, so keeping this API makes rspack-chain's types incompatible with newer `@rspack/core` versions.

## Related Links

https://github.com/web-infra-dev/rspack/commit/d8e690fa31333779e6c25a6aeef37abef460fe88